### PR TITLE
fix 404 on download

### DIFF
--- a/package/tools/chocolateyInstall.ps1
+++ b/package/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
 $elasticsearch_version = $env:ChocolateyPackageVersion
 
-Install-ChocolateyZipPackage 'elasticsearch' "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$($elasticsearch_version).zip" "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+Install-ChocolateyZipPackage 'elasticsearch' "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$($elasticsearch_version)-windows-x86_64.zip" "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 Install-ChocolateyPath "$(Split-Path -parent $MyInvocation.MyCommand.Definition)\elasticsearch-$($elasticsearch_version)\bin"
 


### PR DESCRIPTION
Hi, 
Your package is broken because the URL has changed, now it's something like `https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.1-windows-x86_64.zip`
And we can't put a string like `7.6.1-windows-x86_64` in chocolatey version field.

Could you fix this to let people use your package again ? :) Because this is the only package available with chocolatey.

Thanks!